### PR TITLE
Reduce set env

### DIFF
--- a/scripts/workflows/jobs/steps/curl/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/curl/configure-build-environment.cmd
@@ -1,13 +1,13 @@
-%SW_SET_ENV% SW_LOG_CURL_INFO "%SW_LOG_INFO% --scope curl"
-%SW_SET_ENV% SW_LOG_CURL_WARNING "%SW_LOG_WARNING% --scope curl"
+set "SW_LOG_CURL_INFO=%SW_LOG_INFO% --scope curl"
+set "SW_LOG_CURL_WARNING=%SW_LOG_WARNING% --scope curl"
 
 %SW_LOG_CURL_INFO% --message="Configuring build environment"
 
-%SW_SET_ENV% SW_CURL_REF master
-%SW_SET_ENV% SW_CURL_SOURCES_DIR %SW_SOURCES_DIR%\curl
-%SW_SET_ENV% SW_CURL_BUILD_DIR %SW_BUILD_DIR%\curl
-%SW_SET_ENV% SW_CURL_INSTALL_DIR %SW_INSTALL_DIR%\Library\libcurl-%SW_CURL_VERSION%\usr
-%SW_SET_ENV% SW_ZLIB_DIR %SW_ARTIFACTS_DIR%\Library\zlib-%SW_ZLIB_VERSION%
+set SW_CURL_REF=master
+set "SW_CURL_SOURCES_DIR=%SW_SOURCES_DIR%\curl"
+set "SW_CURL_BUILD_DIR=%SW_BUILD_DIR%\curl"
+set "SW_CURL_INSTALL_DIR=%SW_INSTALL_DIR%\Library\libcurl-%SW_CURL_VERSION%\usr"
+set "SW_ZLIB_DIR=%SW_ARTIFACTS_DIR%\Library\zlib-%SW_ZLIB_VERSION%"
 
 %SW_LOG_CURL_INFO% --prefix="Git ref:           " --message="%SW_CURL_REF%"
 %SW_LOG_CURL_INFO% --prefix="Sources directory: " --message="%SW_CURL_SOURCES_DIR%"

--- a/scripts/workflows/jobs/steps/devtools/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/devtools/configure-build-environment.cmd
@@ -1,40 +1,40 @@
 %SW_LOG_DEVTOOLS_INFO% --prefix="Starting step:" --message="Configure Build Environment"
 
-%SW_SET_ENV% SW_LLBUILD_REF main
-%SW_SET_ENV% SW_TSC_REF main
-%SW_SET_ENV% SW_YAMS_REF master
-%SW_SET_ENV% SW_SAP_REF main
-%SW_SET_ENV% SW_SWIFT_DRIVER_REF main
-%SW_SET_ENV% SW_SPM_REF main
-%SW_SET_ENV% SW_INDEXSTORE_DB_REF main
-%SW_SET_ENV% SW_SOURCEKIT_REF main
+set SW_LLBUILD_REF=main
+set SW_TSC_REF=main
+set SW_YAMS_REF=master
+set SW_SAP_REF=main
+set SW_SWIFT_DRIVER_REF=main
+set SW_SPM_REF=main
+set SW_INDEXSTORE_DB_REF=main
+set SW_SOURCEKIT_REF=main
 
-%SW_SET_ENV% SW_LLBUILD_SOURCES_DIR %SW_SOURCES_DIR%\swift-llbuild
-%SW_SET_ENV% SW_LLBUILD_BUILD_DIR %SW_BUILD_DIR%\swift-llbuild
-%SW_SET_ENV% SW_TSC_SOURCES_DIR %SW_SOURCES_DIR%\swift-tools-support-core
-%SW_SET_ENV% SW_TSC_BUILD_DIR %SW_BUILD_DIR%\swift-tools-support-core
-%SW_SET_ENV% SW_YAMS_SOURCES_DIR %SW_SOURCES_DIR%\Yams
-%SW_SET_ENV% SW_YAMS_BUILD_DIR %SW_BUILD_DIR%\Yams
-%SW_SET_ENV% SW_SAP_SOURCES_DIR %SW_SOURCES_DIR%\swift-argument-parser
-%SW_SET_ENV% SW_SAP_BUILD_DIR %SW_BUILD_DIR%\swift-argument-parser
-%SW_SET_ENV% SW_SWIFT_DRIVER_SOURCES_DIR %SW_SOURCES_DIR%\swift-driver
-%SW_SET_ENV% SW_SWIFT_DRIVER_BUILD_DIR %SW_BUILD_DIR%\swift-driver
-%SW_SET_ENV% SW_SPM_SOURCES_DIR %SW_SOURCES_DIR%\swift-package-manager
-%SW_SET_ENV% SW_SPM_BUILD_DIR %SW_BUILD_DIR%\swift-package-manager
-%SW_SET_ENV% SW_INDEXSTORE_DB_SOURCES_DIR %SW_SOURCES_DIR%\indexstore-db
-%SW_SET_ENV% SW_INDEXSTORE_DB_BUILD_DIR %SW_BUILD_DIR%\indexstore-db
-%SW_SET_ENV% SW_SOURCEKIT_SOURCES_DIR %SW_SOURCES_DIR%\sourcekit-lsp
-%SW_SET_ENV% SW_SOURCEKIT_BUILD_DIR %SW_BUILD_DIR%\sourcekit-lsp
+set "SW_LLBUILD_SOURCES_DIR=%SW_SOURCES_DIR%\swift-llbuild"
+set "SW_LLBUILD_BUILD_DIR=%SW_BUILD_DIR%\swift-llbuild"
+set "SW_TSC_SOURCES_DIR=%SW_SOURCES_DIR%\swift-tools-support-core"
+set "SW_TSC_BUILD_DIR=%SW_BUILD_DIR%\swift-tools-support-core"
+set "SW_YAMS_SOURCES_DIR=%SW_SOURCES_DIR%\Yams"
+set "SW_YAMS_BUILD_DIR=%SW_BUILD_DIR%\Yams"
+set "SW_SAP_SOURCES_DIR=%SW_SOURCES_DIR%\swift-argument-parser"
+set "SW_SAP_BUILD_DIR=%SW_BUILD_DIR%\swift-argument-parser"
+set "SW_SWIFT_DRIVER_SOURCES_DIR=%SW_SOURCES_DIR%\swift-driver"
+set "SW_SWIFT_DRIVER_BUILD_DIR=%SW_BUILD_DIR%\swift-driver"
+set "SW_SPM_SOURCES_DIR=%SW_SOURCES_DIR%\swift-package-manager"
+set "SW_SPM_BUILD_DIR=%SW_BUILD_DIR%\swift-package-manager"
+set "SW_INDEXSTORE_DB_SOURCES_DIR=%SW_SOURCES_DIR%\indexstore-db"
+set "SW_INDEXSTORE_DB_BUILD_DIR=%SW_BUILD_DIR%\indexstore-db"
+set "SW_SOURCEKIT_SOURCES_DIR=%SW_SOURCES_DIR%\sourcekit-lsp"
+set "SW_SOURCEKIT_BUILD_DIR=%SW_BUILD_DIR%\sourcekit-lsp"
 
-%SW_SET_ENV% SW_TOOLCHAIN_DIR %SW_ARTIFACTS_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-%SW_SET_ENV% SW_SDK_DIR %SW_ARTIFACTS_DIR%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk
-%SW_SET_ENV% SW_DEVELOPER_LIBRARY_DIR %SW_ARTIFACTS_DIR%\Library\Developer\Platforms\Windows.platform\Developer\Library
+set "SW_TOOLCHAIN_DIR=%SW_ARTIFACTS_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
+set "SW_SDK_DIR=%SW_ARTIFACTS_DIR%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
+set "SW_DEVELOPER_LIBRARY_DIR=%SW_ARTIFACTS_DIR%\Library\Developer\Platforms\Windows.platform\Developer\Library"
 
-%SW_SET_ENV% SW_TOOLCHAIN_INSTALL_DIR %SW_INSTALL_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
+set "SW_TOOLCHAIN_INSTALL_DIR=%SW_INSTALL_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr"
 
-%SW_SET_ENV% SW_SQLITE_DIR %SW_ARTIFACTS_DIR%\Library\sqlite-%SW_SQLITE_VERSION%
+set "SW_SQLITE_DIR=%SW_ARTIFACTS_DIR%\Library\sqlite-%SW_SQLITE_VERSION%"
 
-set SW_ICU_DIR=%SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%
+set "SW_ICU_DIR=%SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%"
 
-%SW_SET_ENV% PATH "%SW_TOOLCHAIN_DIR%\usr\bin;%SW_SDK_DIR%\usr\bin;%SW_ICU_DIR%\usr\bin;%SW_LLBUILD_BUILD_DIR%\bin;%SW_TSC_BUILD_DIR%\bin;%SW_YAMS_BUILD_DIR%\bin;%SW_SWIFT_DRIVER_BUILD_DIR%\bin;%SW_SAP_BUILD_DIR%\bin;%SW_SPM_BUILD_DIR%\bin;%PATH%"
-%SW_SET_ENV% SWIFTPM_PD_LIBS "%SW_SPM_BUILD_DIR%\pm"
+set "PATH=%SW_TOOLCHAIN_DIR%\usr\bin;%SW_SDK_DIR%\usr\bin;%SW_ICU_DIR%\usr\bin;%SW_LLBUILD_BUILD_DIR%\bin;%SW_TSC_BUILD_DIR%\bin;%SW_YAMS_BUILD_DIR%\bin;%SW_SWIFT_DRIVER_BUILD_DIR%\bin;%SW_SAP_BUILD_DIR%\bin;%SW_SPM_BUILD_DIR%\bin;%PATH%"
+set "SWIFTPM_PD_LIBS=%SW_SPM_BUILD_DIR%\pm"

--- a/scripts/workflows/jobs/steps/devtools/configure-job-environment.cmd
+++ b/scripts/workflows/jobs/steps/devtools/configure-job-environment.cmd
@@ -1,2 +1,2 @@
-%SW_SET_ENV% SW_LOG_DEVTOOLS_INFO "%SW_LOG_INFO% --scope devtools"
-%SW_SET_ENV% SW_LOG_DEVTOOLS_WARNING "%SW_LOG_WARNING% --scope devtools"
+set "SW_LOG_DEVTOOLS_INFO=%SW_LOG_INFO% --scope devtools"
+set "SW_LOG_DEVTOOLS_WARNING=%SW_LOG_WARNING% --scope devtools"

--- a/scripts/workflows/jobs/steps/icu/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/icu/configure-build-environment.cmd
@@ -1,15 +1,15 @@
-%SW_SET_ENV% SW_LOG_ICU_INFO "%SW_LOG_INFO% --scope icu"
-%SW_SET_ENV% SW_LOG_ICU_WARNING "%SW_LOG_WARNING% --scope icu"
+set "SW_LOG_ICU_INFO=%SW_LOG_INFO% --scope icu"
+set "SW_LOG_ICU_WARNING=%SW_LOG_WARNING% --scope icu"
 
 %SW_LOG_ICU_INFO% --message="Configuring build environment"
 
 call "%SW_WORKSPACE%\scripts\tools\get-free-drive.cmd"
 
-%SW_SET_ENV% SW_ICU_REF maint/maint-%SW_ICU_VERSION%
-%SW_SET_ENV% SW_ICU_SOURCES_DIR %SW_SOURCES_DIR%\icu
-%SW_SET_ENV% SW_ICU_BUILD_DIR %SW_BUILD_DIR%\icu
-%SW_SET_ENV% SW_ICU_INSTALL_DIR %SW_INSTALL_DIR%\Library\icu-%SW_ICU_VERSION%\usr
-%SW_SET_ENV% SW_ICU_DRIVE %SW_FREE_DRIVE%
+set SW_ICU_REF=maint/maint-%SW_ICU_VERSION%
+set "SW_ICU_SOURCES_DIR=%SW_SOURCES_DIR%\icu"
+set "SW_ICU_BUILD_DIR=%SW_BUILD_DIR%\icu"
+set "SW_ICU_INSTALL_DIR=%SW_INSTALL_DIR%\Library\icu-%SW_ICU_VERSION%\usr"
+set "SW_ICU_DRIVE=%SW_FREE_DRIVE%"
 
 %SW_LOG_ICU_INFO% --prefix="Git ref:           " --message="%SW_ICU_REF%"
 %SW_LOG_ICU_INFO% --prefix="Sources directory: " --message="%SW_ICU_SOURCES_DIR%"

--- a/scripts/workflows/jobs/steps/libxml2/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/libxml2/configure-build-environment.cmd
@@ -1,12 +1,12 @@
-%SW_SET_ENV% SW_LOG_XML2_INFO "%SW_LOG_INFO% --scope libxml2"
-%SW_SET_ENV% SW_LOG_XML2_WARNING "%SW_LOG_WARNING% --scope libxml2"
+set "SW_LOG_XML2_INFO=%SW_LOG_INFO% --scope libxml2"
+set "SW_LOG_XML2_WARNING=%SW_LOG_WARNING% --scope libxml2"
 
 %SW_LOG_XML2_INFO% --message="Configuring build environment"
 
-%SW_SET_ENV% SW_XML2_REF cmake
-%SW_SET_ENV% SW_XML2_SOURCES_DIR %SW_SOURCES_DIR%\libxml2
-%SW_SET_ENV% SW_XML2_BUILD_DIR %SW_BUILD_DIR%\libxml2
-%SW_SET_ENV% SW_XML2_INSTALL_DIR %SW_INSTALL_DIR%\Library\libxml2-%SW_XML2_VERSION%\usr
+set SW_XML2_REF cmake
+set "SW_XML2_SOURCES_DIR=%SW_SOURCES_DIR%\libxml2"
+set "SW_XML2_BUILD_DIR=%SW_BUILD_DIR%\libxml2"
+set "SW_XML2_INSTALL_DIR=%SW_INSTALL_DIR%\Library\libxml2-%SW_XML2_VERSION%\usr"
 
 %SW_LOG_XML2_INFO% --prefix="Git ref:           " --message="%SW_XML2_REF%"
 %SW_LOG_XML2_INFO% --prefix="Sources directory: " --message="%SW_XML2_SOURCES_DIR%"

--- a/scripts/workflows/jobs/steps/libxml2/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/libxml2/configure-build-environment.cmd
@@ -3,7 +3,7 @@ set "SW_LOG_XML2_WARNING=%SW_LOG_WARNING% --scope libxml2"
 
 %SW_LOG_XML2_INFO% --message="Configuring build environment"
 
-set SW_XML2_REF cmake
+set SW_XML2_REF=cmake
 set "SW_XML2_SOURCES_DIR=%SW_SOURCES_DIR%\libxml2"
 set "SW_XML2_BUILD_DIR=%SW_BUILD_DIR%\libxml2"
 set "SW_XML2_INSTALL_DIR=%SW_INSTALL_DIR%\Library\libxml2-%SW_XML2_VERSION%\usr"

--- a/scripts/workflows/jobs/steps/sdk/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/sdk/configure-build-environment.cmd
@@ -1,67 +1,67 @@
-%SW_SET_ENV% SW_LOG_SDK_INFO "%SW_LOG_INFO% --scope sdk"
-%SW_SET_ENV% SW_LOG_SDK_WARNING "%SW_LOG_WARNING% --scope sdk"
+set "SW_LOG_SDK_INFO=%SW_LOG_INFO% --scope sdk"
+set "SW_LOG_SDK_WARNING=%SW_LOG_WARNING% --scope sdk"
 
 %SW_LOG_SDK_INFO% --message="Configuring build environment"
 
-call scripts\tools\set-env.cmd SW_DISPATCH_REPO apple/swift-corelibs-libdispatch
-call scripts\tools\set-env.cmd SW_DISPATCH_ORIGIN_URL git://github.com/%SW_DISPATCH_REPO%.git
-call scripts\tools\set-env.cmd SW_FOUNDATION_REPO apple/swift-corelibs-foundation
-call scripts\tools\set-env.cmd SW_FOUNDATION_ORIGIN_URL git://github.com/%SW_FOUNDATION_REPO%.git
+set SW_DISPATCH_REPO=apple/swift-corelibs-libdispatch
+set SW_DISPATCH_ORIGIN_URL=git://github.com/%SW_DISPATCH_REPO%.git
+set SW_FOUNDATION_REPO=apple/swift-corelibs-foundation
+set SW_FOUNDATION_ORIGIN_URL=git://github.com/%SW_FOUNDATION_REPO%.git
 
 if [%SW_SWIFT_BRANCH_SPEC%]==[5.3] (
-  if not defined SW_LLVM_REF call scripts\tools\set-env.cmd SW_LLVM_REF swift/release/5.3
-  if not defined SW_DISPATCH_REF call scripts\tools\set-env.cmd SW_DISPATCH_REF release/5.3
-  if not defined SW_SWIFT_REF call scripts\tools\set-env.cmd SW_SWIFT_REF release/5.3
+  if not defined SW_LLVM_REF set SW_LLVM_REF=swift/release/5.3
+  if not defined SW_DISPATCH_REF set SW_DISPATCH_REF=release/5.3
+  if not defined SW_SWIFT_REF set SW_SWIFT_REF=release/5.3
 
-  call scripts\tools\set-env.cmd SW_FOUNDATION_REF release/5.3
-  call scripts\tools\set-env.cmd SW_XCTEST_REF release/5.3
+  set SW_FOUNDATION_REF=release/5.3
+  set SW_XCTEST_REF=release/5.3
 ) else (
-  if not defined SW_LLVM_REF call scripts\tools\set-env.cmd SW_LLVM_REF swift/main
-  if not defined SW_DISPATCH_REF call scripts\tools\set-env.cmd SW_DISPATCH_REF main
-  if not defined SW_SWIFT_REF call scripts\tools\set-env.cmd SW_SWIFT_REF main
+  if not defined SW_LLVM_REF set SW_LLVM_REF=swift/main
+  if not defined SW_DISPATCH_REF set SW_DISPATCH_REF=main
+  if not defined SW_SWIFT_REF set SW_SWIFT_REF =main
 
-  call scripts\tools\set-env.cmd SW_FOUNDATION_REF main
-  call scripts\tools\set-env.cmd SW_XCTEST_REF main
+  set SW_FOUNDATION_REF=main
+  set SW_XCTEST_REF=main
 )
 
 if [%SW_SWIFT_SDK_SPEC%]==[readdle] (
-  call scripts\tools\set-env.cmd SW_FOUNDATION_REPO readdle/swift-corelibs-foundation
-  call scripts\tools\set-env.cmd SW_FOUNDATION_ORIGIN_URL git://github.com/!SW_FOUNDATION_REPO!.git
-  call scripts\tools\set-env.cmd SW_FOUNDATION_REF swift-windows-dev-branch
+  set SW_FOUNDATION_REPO=readdle/swift-corelibs-foundation
+  set SW_FOUNDATION_ORIGIN_URL=git://github.com/!SW_FOUNDATION_REPO!.git
+  set SW_FOUNDATION_REF=swift-windows-dev-branch
 
-  call scripts\tools\set-env.cmd SW_DISPATCH_REPO readdle/swift-corelibs-libdispatch
-  call scripts\tools\set-env.cmd SW_DISPATCH_ORIGIN_URL git://github.com/!SW_DISPATCH_REPO!.git
-  if not defined SW_DISPATCH_REF call scripts\tools\set-env.cmd SW_DISPATCH_REF swift-dev-windows-readdle
+  set SW_DISPATCH_REPO=readdle/swift-corelibs-libdispatch
+  set SW_DISPATCH_ORIGIN_URL=git://github.com/!SW_DISPATCH_REPO!.git
+  if not defined SW_DISPATCH_REF set SW_DISPATCH_REF=swift-dev-windows-readdle
 )
 
-call scripts\tools\set-env.cmd SW_LLVM_PROJECT_SOURCES_DIR %SW_SOURCES_DIR%\llvm-project
-call scripts\tools\set-env.cmd SW_LLVM_SOURCES_DIR %SW_LLVM_PROJECT_SOURCES_DIR%\llvm
-call scripts\tools\set-env.cmd SW_SWIFT_SOURCES_DIR %SW_SOURCES_DIR%\swift
-call scripts\tools\set-env.cmd SW_DISPATCH_SOURCES_DIR %SW_SOURCES_DIR%\swift-corelibs-libdispatch
-call scripts\tools\set-env.cmd SW_FOUNDATION_SOURCES_DIR %SW_SOURCES_DIR%\swift-corelibs-foundation
-call scripts\tools\set-env.cmd SW_XCTEST_SOURCES_DIR %SW_SOURCES_DIR%\swift-corelibs-xctest
+set "SW_LLVM_PROJECT_SOURCES_DIR=%SW_SOURCES_DIR%\llvm-project"
+set "SW_LLVM_SOURCES_DIR=%SW_LLVM_PROJECT_SOURCES_DIR%\llvm"
+set "SW_SWIFT_SOURCES_DIR=%SW_SOURCES_DIR%\swift"
+set "SW_DISPATCH_SOURCES_DIR=%SW_SOURCES_DIR%\swift-corelibs-libdispatch"
+set "SW_FOUNDATION_SOURCES_DIR=%SW_SOURCES_DIR%\swift-corelibs-foundation"
+set "SW_XCTEST_SOURCES_DIR=%SW_SOURCES_DIR%\swift-corelibs-xctest"
 
-call scripts\tools\set-env.cmd SW_LLVM_BUILD_DIR %SW_BUILD_DIR%\llvm
-call scripts\tools\set-env.cmd SW_STDLIB_BUILD_DIR %SW_BUILD_DIR%\swift-stdlib
-call scripts\tools\set-env.cmd SW_DISPATCH_BUILD_DIR %SW_BUILD_DIR%\libdispatch
-call scripts\tools\set-env.cmd SW_FOUNDATION_BUILD_DIR %SW_BUILD_DIR%\foundation
-call scripts\tools\set-env.cmd SW_XCTEST_BUILD_DIR %SW_BUILD_DIR%\xctest
+set "SW_LLVM_BUILD_DIR=%SW_BUILD_DIR%\llvm"
+set "SW_STDLIB_BUILD_DIR=%SW_BUILD_DIR%\swift-stdlib"
+set "SW_DISPATCH_BUILD_DIR=%SW_BUILD_DIR%\libdispatch"
+set "SW_FOUNDATION_BUILD_DIR=%SW_BUILD_DIR%\foundation"
+set "SW_XCTEST_BUILD_DIR=%SW_BUILD_DIR%\xctest"
 
-call scripts\tools\set-env.cmd SW_PLATFORM_PATH=%SW_INSTALL_DIR%\Library\Developer\Platforms\Windows.platform
-call scripts\tools\set-env.cmd SW_SDK_PATH=%SW_PLATFORM_PATH%\Developer\SDKs\Windows.sdk
+set "SW_PLATFORM_PATH=%SW_INSTALL_DIR%\Library\Developer\Platforms\Windows.platform"
+set "SW_SDK_PATH=%SW_PLATFORM_PATH%\Developer\SDKs\Windows.sdk"
 
-call scripts\tools\set-env.cmd SW_SDK_INSTALL_DIR %SW_SDK_PATH%\usr
-call scripts\tools\set-env.cmd SW_XCTEST_INSTALL_PATH %SW_PLATFORM_PATH%\Developer\Library\XCTest-development\usr
+set "SW_SDK_INSTALL_DIR=%SW_SDK_PATH%\usr"
+set "SW_XCTEST_INSTALL_PATH=%SW_PLATFORM_PATH%\Developer\Library\XCTest-development\usr"
 
-call scripts\tools\set-env.cmd SW_TOOLCHAIN_PATH %SW_ARTIFACTS_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-call scripts\tools\set-env.cmd SW_CURL_PATH %SW_ARTIFACTS_DIR%\Library\libcurl-%SW_CURL_VERSION%
-call scripts\tools\set-env.cmd SW_ICU_PATH %SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%
-call scripts\tools\set-env.cmd SW_XML2_PATH %SW_ARTIFACTS_DIR%\Library\libxml2-%SW_XML2_VERSION%
-call scripts\tools\set-env.cmd SW_ZLIB_PATH %SW_ARTIFACTS_DIR%\Library\zlib-%SW_ZLIB_VERSION%
+set "SW_TOOLCHAIN_PATH=%SW_ARTIFACTS_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain"
+set "SW_CURL_PATH=%SW_ARTIFACTS_DIR%\Library\libcurl-%SW_CURL_VERSION%"
+set "SW_ICU_PATH=%SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%"
+set "SW_XML2_PATH=%SW_ARTIFACTS_DIR%\Library\libxml2-%SW_XML2_VERSION%"
+set "SW_ZLIB_PATH=%SW_ARTIFACTS_DIR%\Library\zlib-%SW_ZLIB_VERSION%"
 
-call scripts\tools\set-env.cmd CTEST_OUTPUT_ON_FAILURE 1
+set CTEST_OUTPUT_ON_FAILURE=1
 
-call scripts\tools\set-env.cmd PATH "%SW_TOOLCHAIN_PATH%\usr\bin;%PATH%"
+set "PATH=%SW_TOOLCHAIN_PATH%\usr\bin;%PATH%"
 
 %SW_LOG_SDK_INFO% --prefix="Dispatch origin:         " --message="%SW_DISPATCH_ORIGIN_URL%"
 %SW_LOG_SDK_INFO% --prefix="Foundation origin:       " --message="%SW_FOUNDATION_ORIGIN_URL%"

--- a/scripts/workflows/jobs/steps/sdk/configure-foundation-test-environment.cmd
+++ b/scripts/workflows/jobs/steps/sdk/configure-foundation-test-environment.cmd
@@ -5,4 +5,4 @@ if errorlevel 1 exit /b 0
 
 endlocal
 
-call scripts\tools\set-env.cmd PATH "%SW_ICU_PATH%\usr\bin;%SW_STDLIB_BUILD_DIR%\bin;%SW_DISPATCH_BUILD_DIR%;%SW_FOUNDATION_BUILD_DIR%\Foundation;%SW_XCTEST_BUILD_DIR%;%PATH%;%ProgramFiles%\Git\usr\bin"
+%SW_SET_ENV% PATH "%SW_ICU_PATH%\usr\bin;%SW_STDLIB_BUILD_DIR%\bin;%SW_DISPATCH_BUILD_DIR%;%SW_FOUNDATION_BUILD_DIR%\Foundation;%SW_XCTEST_BUILD_DIR%;%PATH%;%ProgramFiles%\Git\usr\bin"

--- a/scripts/workflows/jobs/steps/sqlite/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/sqlite/configure-build-environment.cmd
@@ -1,12 +1,12 @@
 %SW_LOG_SQLITE_INFO% --prefix="Starting step:" --message="Configure Build Environment"
 
-%SW_SET_ENV% SW_SQLITE_RELEASE 3300100
-%SW_SET_ENV% SW_SQLITE_VERSION 3.30.1
+set SW_SQLITE_RELEASE=3300100
+set SW_SQLITE_VERSION=3.30.1
 
-%SW_SET_ENV% SW_SQLITE_URL https://sqlite.org/2019/sqlite-amalgamation-%SW_SQLITE_RELEASE%.zip
-%SW_SET_ENV% SW_SQLITE_SOURCES_DIR %SW_SOURCES_DIR%\sqlite-amalgamation-%SW_SQLITE_RELEASE%
-%SW_SET_ENV% SW_SQLITE_BUILD_DIR %SW_BUILD_DIR%\sqlite
-%SW_SET_ENV% SW_SQLITE_INSTALL_DIR %SW_INSTALL_DIR%\Library\sqlite-%SW_SQLITE_VERSION%\usr
+set SW_SQLITE_URL=https://sqlite.org/2019/sqlite-amalgamation-%SW_SQLITE_RELEASE%.zip
+set "SW_SQLITE_SOURCES_DIR=%SW_SOURCES_DIR%\sqlite-amalgamation-%SW_SQLITE_RELEASE%"
+set "SW_SQLITE_BUILD_DIR=%SW_BUILD_DIR%\sqlite"
+set "SW_SQLITE_INSTALL_DIR=%SW_INSTALL_DIR%\Library\sqlite-%SW_SQLITE_VERSION%\usr"
 
 %SW_LOG_SQLITE_INFO% --prefix="Sources URL:       " --message="%SW_SQLITE_URL%"
 %SW_LOG_SQLITE_INFO% --prefix="Sources directory: " --message="%SW_SQLITE_SOURCES_DIR%"

--- a/scripts/workflows/jobs/steps/sqlite/configure-job-environment.cmd
+++ b/scripts/workflows/jobs/steps/sqlite/configure-job-environment.cmd
@@ -1,2 +1,2 @@
-%SW_SET_ENV% SW_LOG_SQLITE_INFO "%SW_LOG_INFO% --scope sqlite"
-%SW_SET_ENV% SW_LOG_SQLITE_WARNING "%SW_LOG_WARNING% --scope sqlite"
+set "SW_LOG_SQLITE_INFO=%SW_LOG_INFO% --scope sqlite"
+set "SW_LOG_SQLITE_WARNING=%SW_LOG_WARNING% --scope sqlite"

--- a/scripts/workflows/jobs/steps/toolchain/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/toolchain/configure-build-environment.cmd
@@ -1,36 +1,36 @@
-call scripts\tools\set-env.cmd SW_DISPATCH_REPO apple/swift-corelibs-libdispatch
-call scripts\tools\set-env.cmd SW_DISPATCH_ORIGIN_URL git://github.com/%SW_DISPATCH_REPO%.git
+set SW_DISPATCH_REPO=apple/swift-corelibs-libdispatch
+set SW_DISPATCH_ORIGIN_URL=git://github.com/%SW_DISPATCH_REPO%.git
 
 if [%SW_SWIFT_BRANCH_SPEC%]==[5.3] (
-  call scripts\tools\set-env.cmd SW_LLVM_REF swift/release/5.3
-  call scripts\tools\set-env.cmd SW_CMARK_REF release/5.3
-  call scripts\tools\set-env.cmd SW_DISPATCH_REF release/5.3
-  call scripts\tools\set-env.cmd SW_SWIFT_REF release/5.3
+  set SW_LLVM_REF=swift/release/5.3
+  set SW_CMARK_REF=release/5.3
+  set SW_DISPATCH_REF=release/5.3
+  set SW_SWIFT_REF=release/5.3
 ) else (
-  call scripts\tools\set-env.cmd SW_LLVM_REF swift/main
-  call scripts\tools\set-env.cmd SW_CMARK_REF main
-  call scripts\tools\set-env.cmd SW_DISPATCH_REF main
-  call scripts\tools\set-env.cmd SW_SWIFT_REF main
+  set SW_LLVM_REF=swift/main
+  set SW_CMARK_REF=main
+  set SW_DISPATCH_REF=main
+  set SW_SWIFT_REF=main
 )
 
 if [%SW_SWIFT_SDK_SPEC%]==[readdle] (
-  call scripts\tools\set-env.cmd SW_DISPATCH_REPO readdle/swift-corelibs-libdispatch
-  call scripts\tools\set-env.cmd SW_DISPATCH_ORIGIN_URL git://github.com/!SW_DISPATCH_REPO!.git
-  call scripts\tools\set-env.cmd SW_DISPATCH_REF swift-dev-windows-readdle
+  set SW_DISPATCH_REPO=readdle/swift-corelibs-libdispatch
+  set SW_DISPATCH_ORIGIN_URL=git://github.com/!SW_DISPATCH_REPO!.git
+  set SW_DISPATCH_REF=swift-dev-windows-readdle
 )
 
-call scripts\tools\set-env.cmd SW_LLVM_PROJECT_SOURCES_DIR %SW_SOURCES_DIR%\llvm-project
-call scripts\tools\set-env.cmd SW_LLVM_SOURCES_DIR %SW_LLVM_PROJECT_SOURCES_DIR%\llvm
-call scripts\tools\set-env.cmd SW_CMARK_SOURCES_DIR %SW_SOURCES_DIR%\cmark
-call scripts\tools\set-env.cmd SW_SWIFT_SOURCES_DIR %SW_SOURCES_DIR%\swift
-call scripts\tools\set-env.cmd SW_DISPATCH_SOURCES_DIR %SW_SOURCES_DIR%\swift-corelibs-libdispatch
+set "SW_LLVM_PROJECT_SOURCES_DIR=%SW_SOURCES_DIR%\llvm-project"
+set "SW_LLVM_SOURCES_DIR=%SW_LLVM_PROJECT_SOURCES_DIR%\llvm"
+set "SW_CMARK_SOURCES_DIR=%SW_SOURCES_DIR%\cmark"
+set "SW_SWIFT_SOURCES_DIR=%SW_SOURCES_DIR%\swift"
+set "SW_DISPATCH_SOURCES_DIR=%SW_SOURCES_DIR%\swift-corelibs-libdispatch"
 
-call scripts\tools\set-env.cmd SW_LLVM_TOOLS_BUILD_DIR %SW_BUILD_DIR%\llvm-tools
-call scripts\tools\set-env.cmd SW_TOOLCHAIN_BUILD_DIR %SW_BUILD_DIR%\toolchain
+set "SW_LLVM_TOOLS_BUILD_DIR=%SW_BUILD_DIR%\llvm-tools"
+set "SW_TOOLCHAIN_BUILD_DIR=%SW_BUILD_DIR%\toolchain"
 
-call scripts\tools\set-env.cmd SW_TOOLCHAIN_INSTALL_DIR %SW_INSTALL_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
-call scripts\tools\set-env.cmd SW_ICU_PATH %SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%
+set "SW_TOOLCHAIN_INSTALL_DIR=%SW_INSTALL_DIR%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr"
+set "SW_ICU_PATH=%SW_ARTIFACTS_DIR%\Library\icu-%SW_ICU_VERSION%"
 
-call scripts\tools\set-env.cmd SW_LLVM_TABLEGEN %SW_LLVM_TOOLS_BUILD_DIR%\bin\llvm-tblgen.exe
-call scripts\tools\set-env.cmd SW_CLANG_TABLEGEN %SW_LLVM_TOOLS_BUILD_DIR%\bin\clang-tblgen.exe
-call scripts\tools\set-env.cmd SW_LLDB_TABLEGEN %SW_LLVM_TOOLS_BUILD_DIR%\bin\lldb-tblgen.exe
+set "SW_LLVM_TABLEGEN=%SW_LLVM_TOOLS_BUILD_DIR%\bin\llvm-tblgen.exe"
+set "SW_CLANG_TABLEGEN=%SW_LLVM_TOOLS_BUILD_DIR%\bin\clang-tblgen.exe"
+set "SW_LLDB_TABLEGEN=%SW_LLVM_TOOLS_BUILD_DIR%\bin\lldb-tblgen.exe"

--- a/scripts/workflows/jobs/steps/toolchain/configure-test-environment.cmd
+++ b/scripts/workflows/jobs/steps/toolchain/configure-test-environment.cmd
@@ -5,4 +5,4 @@ if errorlevel 1 exit /b 0
 
 endlocal
 
-call scripts\tools\set-env.cmd PATH "%SW_ICU_PATH%\usr\bin;%SW_TOOLCHAIN_INSTALL_DIR%\bin;%PATH%;%ProgramFiles%\Git\usr\bin"
+%SW_SET_ENV% PATH "%SW_ICU_PATH%\usr\bin;%SW_TOOLCHAIN_INSTALL_DIR%\bin;%PATH%;%ProgramFiles%\Git\usr\bin"

--- a/scripts/workflows/jobs/steps/zlib/configure-build-environment.cmd
+++ b/scripts/workflows/jobs/steps/zlib/configure-build-environment.cmd
@@ -1,12 +1,12 @@
-%SW_SET_ENV% SW_LOG_ZLIB_INFO "%SW_LOG_INFO% --scope zlib"
-%SW_SET_ENV% SW_LOG_ZLIB_WARNING "%SW_LOG_WARNING% --scope zlib"
+set "SW_LOG_ZLIB_INFO=%SW_LOG_INFO% --scope zlib"
+set "SW_LOG_ZLIB_WARNING=%SW_LOG_WARNING% --scope zlib"
 
 %SW_LOG_ZLIB_INFO% --message="Configuring build environment"
 
-%SW_SET_ENV% SW_ZLIB_REF refs/tags/v%SW_ZLIB_VERSION%
-%SW_SET_ENV% SW_ZLIB_SOURCES_DIR %SW_SOURCES_DIR%\zlib
-%SW_SET_ENV% SW_ZLIB_BUILD_DIR %SW_BUILD_DIR%\zlib
-%SW_SET_ENV% SW_ZLIB_INSTALL_DIR %SW_INSTALL_DIR%\Library\zlib-%SW_ZLIB_VERSION%\usr
+set SW_ZLIB_REF=refs/tags/v%SW_ZLIB_VERSION%
+set SW_ZLIB_SOURCES_DIR=%SW_SOURCES_DIR%\zlib
+set "SW_ZLIB_BUILD_DIR=%SW_BUILD_DIR%\zlib"
+set "SW_ZLIB_INSTALL_DIR=%SW_INSTALL_DIR%\Library\zlib-%SW_ZLIB_VERSION%\usr"
 
 %SW_LOG_ZLIB_INFO% --prefix="Git ref:           " --message="%SW_ZLIB_REF%"
 %SW_LOG_ZLIB_INFO% --prefix="Sources directory: " --message="%SW_ZLIB_SOURCES_DIR%"


### PR DESCRIPTION
Most of set-env tool calls could be replaced with plain `set`, as we have bulk environment export at the end of a configuration step.